### PR TITLE
Adding Language Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ import '@khmyznikov/pwa-install';
   manual-chrome="true"
   disable-chrome="true"
 
-  language="en"
-
   install-description="Custom call to install text"
   disable-install-description="true"
   disable-screenshots="true"
+
+  <!-- do not recommend to force the language --->
+  language="en"
 
   manifest-url="/manifest.json"
   name="PWA"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ import '@khmyznikov/pwa-install';
   manual-chrome="true"
   disable-chrome="true"
 
+  language="en"
+
   install-description="Custom call to install text"
   disable-install-description="true"
   disable-screenshots="true"

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,8 @@
 
 			<label>
 				<select id="language" onchange="setAttr('language', this.value)">
-					<option value="en" selected>en</option>
+					<option disabled selected>Language override</option>
+					<option value="en">en</option>
 					<option value="ru">ru</option>
 					<option value="tr">tr</option>
 					<option value="de">de</option>
@@ -98,8 +99,8 @@
 					<option value="zh-CN">zh-CN</option>
 					<option value="it">it</option>
 					<option value="cs">cs</option>					
-				</select>
-				Language
+				</select><br>
+				Don't recommend to use in prod
 			</label>
 		</fieldset>
 		<fieldset>
@@ -175,7 +176,7 @@
 		const setAttr = (attr, value) => {
 			value? pwaInstall.setAttribute(attr, value) :
 			pwaInstall.removeAttribute(attr);
-			pwaInstall._init();
+			attr != 'language' && pwaInstall._init();
 		}
 
 		pwaInstall.addEventListener('pwa-install-success-event', (event) => {logMessage(event.detail.message)});

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,28 @@
 			</label><hr>
 	
 			<input type="text" placeholder="App name text" onchange="setAttr('name', this.value)"><br>
-			<input type="text" placeholder="App description text" onchange="setAttr('description', this.value)"><br>
+			<input type="text" placeholder="App description text" onchange="setAttr('description', this.value)"><br><hr>
+
+			<label>
+				<select id="language" onchange="setAttr('language', this.value)">
+					<option value="en" selected>en</option>
+					<option value="ru">ru</option>
+					<option value="tr">tr</option>
+					<option value="de">de</option>
+					<option value="es">es</option>
+					<option value="nl">nl</option>
+					<option value="el">el</option>
+					<option value="fr">fr</option>
+					<option value="sr">sr</option>
+					<option value="pl">pl</option>
+					<option value="uk">uk</option>
+					<option value="zh">zh</option>
+					<option value="zh-CN">zh-CN</option>
+					<option value="it">it</option>
+					<option value="cs">cs</option>					
+				</select>
+				Language
+			</label>
 		</fieldset>
 		<fieldset>
 			<legend>

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export class PWAInstallElement extends LitElement {
 	@property() icon = '';
 	@property() name = '';
 	@property() description = '';
+	@property({attribute: 'language'}) language = navigator.language;
 	@property({attribute: 'install-description'}) installDescription = '';
 	@property({attribute: 'disable-install-description', type: Boolean}) disableDescription = false;
 	@property({attribute: 'disable-screenshots', type: Boolean}) disableScreenshots = false;
@@ -180,6 +181,7 @@ export class PWAInstallElement extends LitElement {
 	}
 	/** @internal */
 	private _init = async () => {
+		changeLocale(this.language)
 		window.defferedPromptEvent = null;
 
 		this._checkInstalled();
@@ -243,7 +245,6 @@ export class PWAInstallElement extends LitElement {
 	}
 
 	connectedCallback() {
-		changeLocale(navigator.language);
 		this._init();
 		PWAGalleryElement.finalized;
 		PWABottomSheetElement.finalized;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,14 +27,15 @@ import templateApple from './templates/apple/template-apple';
  * @event {CustomEvent} pwa-install-how-to-event - App install instruction showed
  * @event {CustomEvent} pwa-install-gallery-event - App install gallery showed
  */
-@localized()
+
 @customElement('pwa-install')
+@localized()
 export class PWAInstallElement extends LitElement {
 	@property({attribute: 'manifest-url'}) manifestUrl = '/manifest.json';
 	@property() icon = '';
 	@property() name = '';
 	@property() description = '';
-	@property({attribute: 'language'}) language = navigator.language;
+	@property() language = navigator.language;
 	@property({attribute: 'install-description'}) installDescription = '';
 	@property({attribute: 'disable-install-description', type: Boolean}) disableDescription = false;
 	@property({attribute: 'disable-screenshots', type: Boolean}) disableScreenshots = false;
@@ -181,7 +182,6 @@ export class PWAInstallElement extends LitElement {
 	}
 	/** @internal */
 	private _init = async () => {
-		changeLocale(this.language)
 		window.defferedPromptEvent = null;
 
 		this._checkInstalled();
@@ -245,12 +245,16 @@ export class PWAInstallElement extends LitElement {
 	}
 
 	connectedCallback() {
+		changeLocale(this.language);
 		this._init();
 		PWAGalleryElement.finalized;
 		PWABottomSheetElement.finalized;
 		super.connectedCallback();
 	}
 	willUpdate(changedProperties: PropertyValues<this>) {
+		if (changedProperties.has('language')) {
+			changeLocale(this.language);
+		}
 		if (this.externalPromptEvent && changedProperties.has('externalPromptEvent') && typeof this.externalPromptEvent == 'object') {
 		  this._init();
 		}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -16,6 +16,7 @@ export interface PWAInstallAttributes {
     ['manual-apple']?: Booleanish;
     ['manual-chrome']?: Booleanish;
     ['disable-chrome']?: Booleanish;
+    ['language']?: string;
     ['install-description']?: string;
     ['disable-install-description']?: Booleanish;
     ['manifest-url']?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,6 @@
         "name": "typescript-lit-html-plugin"
       }
     ]
-  }
+  },
+  "exclude": ["src/fallback"]
 }


### PR DESCRIPTION
I have a little web app ([website](https://deep.valentinhuber.me), [GitHub](https://github.com/riesentoaster/deep)) written in react. It has translations in German and English. I'd love to add a prompt to install it as a PWA (currently I'm just linking to an explanation, but that's pretty ugly).

However, to do this I need to be able to control the language of the prompt or at least have it be reactive to the language set by my system (based on `react-i18next`, updating `document.documentElement.lang`). Along with this, I'd need to control all text elements that are based on the app (specifically `install-description`) dynamically.

I've given implementing setting a language from the outside a shot in this PR. I have no experience with Lit, so this may not be the right approach, but at least the demo (which I also extended) works.

Still missing (I'm not sure how much of a help I'll be here — I don't know the system well enough):
- [ ] Test if this actually works "in real life" — I've only tested the demo
- [ ] Possibly reduce the lag until the language is updated (currently ~1s)
- [ ] Check if the other params (specifically `install-description`) are also dynamic, and if not change them to be

What do you think?