### PR TITLE
Feat: Filter screenshots based on form_factor & added Alt text

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -29,12 +29,14 @@
         {
 			"src": "screenshots/mobile-2.jpg",
 			"sizes": "518x922",
-			"type": "image/jpeg"
+			"type": "image/jpeg",
+			"form_factor": "narrow"
 		},
         {
 			"src": "screenshots/mobile-3.jpg",
 			"sizes": "518x922",
-			"type": "image/jpeg"
+			"type": "image/jpeg",
+			"form_factor": "narrow"
 		},
         {
 			"src": "screenshots/tablet-1.jpg",

--- a/src/gallery/index.ts
+++ b/src/gallery/index.ts
@@ -1,13 +1,13 @@
 import { LitElement, html } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
-import { PWAScreenhot } from '../types/types';
+import { ManifestScreenshot } from '../types/types';
 
 import styles from './styles-gallery.scss';
 import template from './template-gallery';
 
 @customElement('pwa-gallery')
 export default class PWAGalleryElement extends LitElement {
-	@property() screenshots: PWAScreenhot[] = [];
+	@property({ type: Array }) screenshots: ManifestScreenshot[] = [];
 	@property() theme: 'default' | 'apple_desktop' | 'apple_mobile' = 'default';
 
 	static get styles() {

--- a/src/gallery/index.ts
+++ b/src/gallery/index.ts
@@ -1,13 +1,13 @@
 import { LitElement, html } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
-import { WebAppManifest } from 'web-app-manifest';
+import { PWAScreenhot } from '../types/types';
 
 import styles from './styles-gallery.scss';
 import template from './template-gallery';
 
 @customElement('pwa-gallery')
 export default class PWAGalleryElement extends LitElement {
-	@property() screenshots: WebAppManifest['screenshots'] = [];
+	@property() screenshots: PWAScreenhot[] = [];
 	@property() theme: 'default' | 'apple_desktop' | 'apple_mobile' = 'default';
 
 	static get styles() {

--- a/src/gallery/template-gallery.ts
+++ b/src/gallery/template-gallery.ts
@@ -1,8 +1,8 @@
 import { html } from 'lit';
 import Utils from '../utils';
-import { PWAScreenhot } from '../types/types';
+import { ManifestScreenshot } from '../types/types';
 
-const template = (screenshots: PWAScreenhot[], theme: string, scrollToNextPage: any, scrollToPrevPage: any) => {
+const template = (screenshots: ManifestScreenshot[], theme: string, scrollToNextPage: any, scrollToPrevPage: any) => {
 
     return html`
         ${screenshots? html`

--- a/src/gallery/template-gallery.ts
+++ b/src/gallery/template-gallery.ts
@@ -1,13 +1,15 @@
 import { html } from 'lit';
-import { WebAppManifest } from 'web-app-manifest';
+import Utils from '../utils';
+import { PWAScreenhot } from '../types/types';
 
-const template = (screenshots: WebAppManifest['screenshots'], theme: string, scrollToNextPage: any, scrollToPrevPage: any) => {
+const template = (screenshots: PWAScreenhot[], theme: string, scrollToNextPage: any, scrollToPrevPage: any) => {
+
     return html`
         ${screenshots? html`
             <div id="paginated_gallery" class="gallery ${theme}">
                 <div class="gallery_scroller">
                     <div class="scroller_wrap">
-                        ${screenshots.map(screenshot => html`<img draggable="false" src='${screenshot.src}'>`)}
+                        ${screenshots.filter(screenshot => !screenshot.form_factor || screenshot.form_factor === Utils.deviceFormFactor()).map(screenshot => html`<img draggable="false" src='${screenshot.src}' alt='${screenshot.label || ""}'>`)}
                     </div>
                 </div>
                 <span class="btn prev" @click="${scrollToPrevPage}">

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,7 +24,7 @@ export interface PWAInstallAttributes {
     icon?: string;
 }
 
-export interface PWAScreenhot extends ImageResource {
+export interface ManifestScreenshot extends ImageResource {
     label?: string;
     platform?: string;
     form_factor?: "wide" | "narrow";
@@ -40,7 +40,7 @@ export class Manifest {
     }
     short_name: string;
     icons: ImageResource[];
-    screenshots?: PWAScreenhot[];
+    screenshots?: ManifestScreenshot[];
     name: string;
     description: string;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,6 +24,12 @@ export interface PWAInstallAttributes {
     icon?: string;
 }
 
+export interface PWAScreenhot extends ImageResource {
+    label?: string;
+    platform?: string;
+    form_factor?: "wide" | "narrow";
+}
+
 export class Manifest {
     constructor() {
         this.icons = [{ src: '' }];
@@ -34,7 +40,7 @@ export class Manifest {
     }
     short_name: string;
     icons: ImageResource[];
-    screenshots?: ImageResource[];
+    screenshots?: PWAScreenhot[];
     name: string;
     description: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,10 @@ export default class Utils {
 
         return audioCheck && webGLCheck;
     }
+
+    static deviceFormFactor(): 'narrow' | 'wide' {
+        return window.matchMedia('(orientation: portrait)').matches? 'narrow' : 'wide';
+    }
     
     static isStandalone() {
 		if (window.matchMedia('(display-mode: standalone)').matches || ('standalone' in navigator && (navigator as any).standalone === true))


### PR DESCRIPTION
The form_factor member is a [string](https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf#) that represents the screen shape of a broad class of devices for which a given screenshot applies. Authors are encouraged to only use this member when the screenshot is only applicable in a specific context.

This PR filters the screenshots to remove those with the form_factor different from the user's client. If the screenshot does not have a form_factor specified, it will be shown.

Also added alt text for the screenshots.

## Note on Types
The current types package doesn't seem to correctly type screenshots, which actually have an extension beyond ImageResource. Therefore I created my own type here.
https://www.w3.org/TR/manifest-app-info/#dfn-screenshots-object

## Resolves:
- https://github.com/khmyznikov/pwa-install/issues/95

