### PR TITLE
FIX small typo in Czech translation in cs.xlf

### DIFF
--- a/i18n/cs.xlf
+++ b/i18n/cs.xlf
@@ -12,7 +12,7 @@
       </trans-unit>
       <trans-unit id="s37a9e8aec5713460">
         <source>More</source>
-        <target>Vice</target>
+        <target>Více</target>
       </trans-unit>
       <trans-unit id="s1b9047d53d9f9d22">
         <source>2) Press Share in Navigation bar</source>


### PR DESCRIPTION
Hey, I have fixed minor translation typo in Czech translation of "More" which was missing interpuction so now it says "Více". instead of "Vice". 😁 
