### PR TITLE
Fix ios pwa dutch translations

### DIFF
--- a/i18n/nl.xlf
+++ b/i18n/nl.xlf
@@ -16,7 +16,7 @@
       </trans-unit>
       <trans-unit id="scdaf4bbff76674c8">
         <source>Add to Home Screen</source>
-        <target>Toevoegen aan het startscherm</target>
+        <target>Zet op beginscherm</target>
       </trans-unit>
       <trans-unit id="sfea652f6580ff086">
         <source>This site has app functionality.</source>
@@ -28,7 +28,7 @@
       </trans-unit>
       <trans-unit id="s182ab2d6c997515f">
         <source>Add it to your Home Screen for extensive experience and easy access.</source>
-        <target>Voeg het toe aan je startscherm voor een uitgebreide ervaring en gemakkelijke toegang.</target>
+        <target>Zet het op je beginscherm voor een uitgebreide ervaring en gemakkelijke toegang.</target>
       </trans-unit>
       <trans-unit id="s8114bd55cae5a22b">
         <source>Press Add to Dock</source>
@@ -48,7 +48,7 @@
       </trans-unit>
       <trans-unit id="s4e1e10a6ca408245">
         <source>Tap "Add to Home screen"</source>
-        <target>Tik op "Toevoegen aan startscherm"</target>
+        <target>Tik op "Zet op beginscherm"</target>
       </trans-unit>
       <trans-unit id="s386eca8362ff6155">
         <source>Press More if no Share icon</source>
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="se0e473adfda8066c">
         <source>Open in your main browser</source>
-        <target>Open in je hoofdprogramma</target>
+        <target>Open in je hoofdbrowser</target>
       </trans-unit>
       <trans-unit id="s224cbcec014ef6b5">
         <source>Press Share in Navigation bar</source>
@@ -72,7 +72,7 @@
       </trans-unit>
       <trans-unit id="s9af56bf005b49c74">
         <source>Scroll down to "Add to Home Screen"</source>
-        <target>Scrol naar beneden naar "Toevoegen aan startscherm"</target>
+        <target>Scrol omlaag en klik op "Zet op beginscherm"</target>
       </trans-unit>
       <trans-unit id="s7f0591f08e318eda">
         <source>Press More in Share menu</source>


### PR DESCRIPTION
These fixes are related to the open issue [Dutch iOS PWA install translations aren't correct](https://github.com/khmyznikov/pwa-install/issues/133). The translations were grammatically correct but didn't match the actual text shown in the iOS Safari share menu (see screenshot).

**Localization improvements**

* Updated Dutch translations in `i18n/nl.xlf` and `src/localization/locales/nl.ts` to use clearer, more natural phrasing for instructions related to adding the app to the home screen and browser terminology. 
* Added missing Serbian translations in `i18n/sr.xlf` and `src/localization/locales/sr.ts` for "Add to Home Screen" and "Add to Dock", improving completeness for Serbian users.

<img width="828" height="1792" alt="image" src="https://github.com/user-attachments/assets/1c7c2a79-3e36-486c-84a1-a27e64182861" />
The new text now matches what iOS users actually see in their Safari share menu, making the instructions clearer and easier to follow.