### PR TITLE
feat(i18n): add Traditional Chinese (zh-TW) translation

### DIFF
--- a/i18n/zh-TW.xlf
+++ b/i18n/zh-TW.xlf
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="zh-TW" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="se740f75b95a51807">
+  <source>Add it to your Dock for extensive experience and easy access.</source>
+  <target>將其加入 Dock，以獲得更完整的體驗並方便隨時存取。</target>
+</trans-unit>
+<trans-unit id="s182ab2d6c997515f">
+  <source>Add it to your Home Screen for extensive experience and easy access.</source>
+  <target>將其加入主畫面，以獲得更完整的體驗並方便存取。</target>
+</trans-unit>
+<trans-unit id="se0e473adfda8066c">
+  <source>Open in your main browser</source>
+  <target>在主瀏覽器中開啟</target>
+</trans-unit>
+<trans-unit id="s386eca8362ff6155">
+  <source>Press More if no Share icon</source>
+  <target>若未看見「分享」圖示，請點擊「更多」</target>
+</trans-unit>
+<trans-unit id="s224cbcec014ef6b5">
+  <source>Press Share in Navigation bar</source>
+  <target>點擊導覽列中的「分享」按鈕</target>
+</trans-unit>
+<trans-unit id="s7f0591f08e318eda">
+  <source>Press More in Share menu</source>
+  <target>在分享選單中點擊更多</target>
+</trans-unit>
+<trans-unit id="s8114bd55cae5a22b">
+  <source>Press Add to Dock</source>
+  <target>點擊「加入 Dock」</target>
+</trans-unit>
+<trans-unit id="s9af56bf005b49c74">
+  <source>Scroll down to "Add to Home Screen"</source>
+  <target>向下捲動至「加入主畫面」</target>
+</trans-unit>
+<trans-unit id="sc16e00a7a8b2fde2">
+  <source>Back</source>
+  <target>返回</target>
+</trans-unit>
+<trans-unit id="s681e399d63311fba">
+  <source>Show Gallery</source>
+  <target>顯示相簿</target>
+</trans-unit>
+<trans-unit id="s922329d6f6213590">
+  <source>Add to Dock</source>
+  <target>加入 Dock</target>
+</trans-unit>
+<trans-unit id="scdaf4bbff76674c8">
+  <source>Add to Home Screen</source>
+  <target>加入主畫面</target>
+</trans-unit>
+<trans-unit id="s6196153c4b0c1ea0">
+  <source>Install</source>
+  <target>安裝</target>
+</trans-unit>
+<trans-unit id="s633502f7cff4f847">
+  <source>Open your browser menu</source>
+  <target>開啟瀏覽器選單</target>
+</trans-unit>
+<trans-unit id="s4e1e10a6ca408245">
+  <source>Tap "Add to Home screen"</source>
+  <target>輕觸「加入主畫面」</target>
+</trans-unit>
+<trans-unit id="sfea652f6580ff086">
+  <source>This site has app functionality.</source>
+  <target>此網站具備應用程式功能。</target>
+</trans-unit>
+<trans-unit id="sba52286c21552a4e">
+  <source>Install it on your device for extensive experience and easy access.</source>
+  <target>在您的裝置上安裝，以獲得更完整的體驗並方便存取。</target>
+</trans-unit>
+<trans-unit id="sa5ef80b4bb9b39f8">
+  <source>Less</source>
+  <target>收起</target>
+</trans-unit>
+<trans-unit id="s37a9e8aec5713460">
+  <source>More</source>
+  <target>更多</target>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/lit-localize.json
+++ b/lit-localize.json
@@ -16,6 +16,7 @@
     "uk",
     "zh-HK",
     "zh-CN",
+    "zh-TW",
     "it",
     "cs",
     "no",

--- a/src/localization/index.ts
+++ b/src/localization/index.ts
@@ -18,6 +18,7 @@ import * as pl from "./locales/pl";
 import * as uk from "./locales/uk";
 import * as zhHK from "./locales/zh-HK";
 import * as zhCN from "./locales/zh-CN";
+import * as zhTW from "./locales/zh-TW";
 import * as it from "./locales/it";
 import * as cs from "./locales/cs";
 import * as no from "./locales/no";
@@ -49,6 +50,7 @@ const localizedTemplates = new Map([
   ['uk', uk],
   ['zh-HK', zhHK],
   ['zh-CN', zhCN],
+  ['zh-TW', zhTW],
   ['it', it],
   ['cs', cs],
   ['no', no], // + nb
@@ -86,7 +88,6 @@ export const changeLocale = async (lang: string) => {
   // Fallback to simplified Chinese
   switch (lang) {
     case 'zh':
-    case 'zh-TW':
       lang = 'zh-CN';
       break;
     default:

--- a/src/localization/locale-codes.ts
+++ b/src/localization/locale-codes.ts
@@ -40,6 +40,7 @@ export const targetLocales = [
   `vi`,
   `zh-CN`,
   `zh-HK`,
+  `zh-TW`,
 ] as const;
 
 /**
@@ -76,4 +77,5 @@ export const allLocales = [
   `vi`,
   `zh-CN`,
   `zh-HK`,
+  `zh-TW`,
 ] as const;

--- a/src/localization/locales/zh-TW.ts
+++ b/src/localization/locales/zh-TW.ts
@@ -1,0 +1,32 @@
+
+    // Do not modify this file by hand!
+    // Re-generate this file by running lit-localize
+
+    
+    
+
+    /* eslint-disable no-irregular-whitespace */
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+
+    export const templates = {
+      's182ab2d6c997515f': `將其加入主畫面，以獲得更完整的體驗並方便存取。`,
+'s224cbcec014ef6b5': `點擊導覽列中的「分享」按鈕`,
+'s37a9e8aec5713460': `更多`,
+'s386eca8362ff6155': `若未看見「分享」圖示，請點擊「更多」`,
+'s4e1e10a6ca408245': `輕觸「加入主畫面」`,
+'s6196153c4b0c1ea0': `安裝`,
+'s633502f7cff4f847': `開啟瀏覽器選單`,
+'s681e399d63311fba': `顯示相簿`,
+'s7f0591f08e318eda': `在分享選單中點擊更多`,
+'s8114bd55cae5a22b': `點擊「加入 Dock」`,
+'s922329d6f6213590': `加入 Dock`,
+'s9af56bf005b49c74': `向下捲動至「加入主畫面」`,
+'sa5ef80b4bb9b39f8': `收起`,
+'sba52286c21552a4e': `在您的裝置上安裝，以獲得更完整的體驗並方便存取。`,
+'sc16e00a7a8b2fde2': `返回`,
+'scdaf4bbff76674c8': `加入主畫面`,
+'se0e473adfda8066c': `在主瀏覽器中開啟`,
+'se740f75b95a51807': `將其加入 Dock，以獲得更完整的體驗並方便隨時存取。`,
+'sfea652f6580ff086': `此網站具備應用程式功能。`,
+    };
+  


### PR DESCRIPTION
This pull request adds support for Traditional Chinese (zh-TW) localization to the project. It introduces the necessary translation files, updates configuration and locale lists, and ensures that zh-TW is handled as a separate locale rather than falling back to Simplified Chinese.

**Traditional Chinese (zh-TW) Localization Support:**

* Added a new translation file `zh-TW.ts` with Traditional Chinese strings for all relevant UI messages.
* Added a new XLIFF translation file `zh-TW.xlf` containing all Traditional Chinese translations.

**Configuration and Locale Handling:**

* Updated locale lists in `locale-codes.ts`, `lit-localize.json`, and the localization index to include `zh-TW` as a supported language. [[1]](diffhunk://#diff-e1b5ea3cf44e3af6de8d596bba1d421612fedcad4c9af7616faf283af9de60eaR43) [[2]](diffhunk://#diff-e1b5ea3cf44e3af6de8d596bba1d421612fedcad4c9af7616faf283af9de60eaR80) [[3]](diffhunk://#diff-9dbf02d2b3904f08b8010114e2f35b203938f84a21cce37fcdc5a40b5e7df6cfR19) [[4]](diffhunk://#diff-578a4fa765c4a6fcd577428be6988edf9f6ee198b00a6f05f3d2d1aa504c5a69R21) [[5]](diffhunk://#diff-578a4fa765c4a6fcd577428be6988edf9f6ee198b00a6f05f3d2d1aa504c5a69R53)
* Modified the locale fallback logic to ensure `zh-TW` does not fall back to `zh-CN` (Simplified Chinese), allowing it to be treated as an independent locale.